### PR TITLE
Fix MSQ-Only Stormhaven guide to appear in the correct folder

### DIFF
--- a/Guides/MainQuestsOnly.lua
+++ b/Guides/MainQuestsOnly.lua
@@ -5883,7 +5883,7 @@ talk Captain Rana
 turnin Escape from Bleakrock |next Ebonheart Pact Leveling Guides\\Main Quests Only\\Ebonheart Pact\\Stonefalls
 ]])
 
-ZGV:RegisterGuide("Daggerfall Covenant Leveling Guides\\Main Quests Only\\Daggerfall Covenant\Stormhaven",[[
+ZGV:RegisterGuide("Daggerfall Covenant Leveling Guides\\Main Quests Only\\Daggerfall Covenant\\Stormhaven",[[
 loadingimage loadscreen_stormhaven_01.dds
 description I spent some time studying and painting in the Stormhaven countryside; a charming realm of rolling hills, lush flood plains, rocky outcrops, and copses of ancient woodland. The place would be idyllic were it not for the perpetual unsettled gloom, occasional crackles of thunder, and bolts of Kynareth’s rage that arc across the skies.
 step


### PR DESCRIPTION
This was just a simple typo in the LUA file. Fixing it will put the MSQ-only Stormhaven guide in the correct folder.