### PR TITLE
Add "/zgv dev" command to toggle ZGV.DEV

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -82,6 +82,7 @@ local defaultChar = {
   stephistory = {},
   goodbadguides = {},
   ignoredguides = {},
+  developer = false,
 }
 
 -- These are the account settings like options that will likely be the same for all characters.

--- a/SlashCommands.lua
+++ b/SlashCommands.lua
@@ -47,6 +47,10 @@ function ZGV.SlashCommandHandler(text)		--TODO
 		ZGV.Viewer:Hide_GuideViewer()
 	elseif text == "config" then
 		ZGV.Settings:OpenSettings()
+	elseif text == "dev" or text=="developer" then
+		ZGV.DEV = not ZGV.DEV
+		self.sv.char.developer = not self.sv.char.developer
+		ZGV:Print(("Developer Mode is now %s"):format(self.sv.char.developer and "on" or "off"))
 	else
 		ZGV:Print(help_string)
 	end

--- a/ZGESO.lua
+++ b/ZGESO.lua
@@ -194,6 +194,10 @@ local function ZGV_Initialized(eventCode, addOnName)
 
   self.sv:Setup() -- Get our saved variables set up first thing
 
+  if (self.sv.char.developer) then
+    ZGV.DEV = true
+  end
+
   self:RegisterKeyBindings() -- What appears in the ESO > CONTROLS > Keybindings window
 
   -- pre-startup 'modules', if anyone wants to run stuff at addon init, before the troo startups.


### PR DESCRIPTION
This adds the following syntax option to the main slash command:   `/zgv dev`     Using this command TOGGLES on or off the existing developer functionality within the addon.   The setting is per character, and is persistent.

Most of what this adds deals with spewing additional information to the chat window, such as when you first load the UI or at the end of every guide viewer step, etc.; however, there are some other features as well, which can be found by searching through the source for `ZGV.DEV`.

The other main thing that it should do, although I haven't tested it as yet, is start adding data to the `/SavedVariables/ZGESO.lua` file for any **new** questIDs, objectIds, npcIds, or itemIds the player encounters.    Those arrays are in the file under `profiles -> main -> data`    I believe it is intended to be used for creating new guides.

What I would like to do next is set it so that "developer mode" provides information specific to addon developers -- but, then create a new "creator mode" that will provide information to guide creators as they are playing the game (e.g., show a text message with achievement progress, etc.)   I think there are a lot more things the ESOUI API is capable of now than was available in 2014.

