### PR TITLE
Add Creator Mode and initial features

### DIFF
--- a/Debug.lua
+++ b/Debug.lua
@@ -104,7 +104,11 @@ end
 function ZGV:Print(str,...)
 	str = string.format(tostring(str),...)
 	-- TODO
-	print(L['name']..": "..str)
+	if (ZGV.Creator) then
+		print(L['name'].." |ceeeecc[Creator]|r: "..str)
+	else
+		print(L['name']..": "..str)
+	end
 end
 
 -----------------------------------------

--- a/Debug.lua
+++ b/Debug.lua
@@ -106,6 +106,8 @@ function ZGV:Print(str,...)
 	-- TODO
 	if (ZGV.Creator) then
 		print(L['name'].." |ceeeecc[Creator]|r: "..str)
+	elseif (ZGV.DEV) then
+		print(L['name'].." |ceeeecc[DEV]|r: "..str)
 	else
 		print(L['name']..": "..str)
 	end

--- a/Events.lua
+++ b/Events.lua
@@ -98,6 +98,91 @@ function ZGV:EVENT_PLAYER_COMBAT_STATE(_,state)
 	end
 end
 
+-- EVENT_ACHIEVEMENT_AWARDED (*string* _name_, *integer* _points_, *integer* _id_, *string* _link_)
+function ZGV.EVENT_ACHIEVEMENT_AWARDED(_,_,name,points,id,_)
+	if (ZGV.Creator) then
+		ZGV:Print("achieve %d", id)
+		ZGV:Print("|cd3d3d3(Name: %s)|r", name)
+	end
+end
+
+-- EVENT_ACHIEVEMENT_UPDATED (*integer* _id_)
+function ZGV.EVENT_ACHIEVEMENT_UPDATED(_,_,id)
+	local IgnoreAchievements = {
+		[19] = "Treasure Chest Spotter",
+		[20] = "Treasure Chest Seeker",
+		[21] = "Treasure Chest Stalker",
+		[22] = "Treasure Chest Hunter",
+		[38] = "Humanoid Slayer",
+		[39] = "Daedra Slayer",
+		[40] = "Dwarven Construct Slayer",
+		[41] = "Nature Slayer",
+		[42] = "Undead Slayer",
+		[52] = "Quester",
+		[53] = "Explorer",
+		[54] = "Adventurer",
+		[55] = "Master Adventurer",
+		[56] = "Indomitable Adventurer",
+		[64] = "Apprentice Crafting Harvester",
+		[65] = "Journeyman Crafting Harvester",
+		[66] = "Expert Crafting Harvester",
+		[67] = "Master Crafting Harvester",
+		[68] = "Grand Master Crafting Harvester",
+		[709] = "Dungeon Lord",
+		[710] = "Dungeon Marauder",
+		[711] = "Dungeon Annilhilator",
+		[752] = "Greater Dungeon Healer",
+		[753] = "Dungeon Blocker",
+		[754] = "Greater Dungeon Blocker",
+		[1019] = "Master Deconstructor",
+		[1026] = "Recipe Card",
+		[1027] = "Recipe Book",
+		[1028] = "Recipe Book Compendium",
+		[1148] = "Signed the Manifest",
+		[1149] = "Writ Upon the Sky",
+	}
+	if not IgnoreAchievements[id] then
+		if (ZGV.Creator) then
+			local name,desc,_,_,isCompleted,_,_ = _G.GetAchievementInfo(id)
+			local isSkyshardAchievement,_ = string.find(name,"Skyshard")
+			--ZGV:Print("|cd3d3d3Achievement Updated: %d:%s (isCompleted: %s)|r",id,name,tostring(isCompleted))                  -- DEBUG
+			--ZGV:Print("|cd3d3d3- isSkyshardAchievement: %s|r", tostring(isSkyshardAchievement))                                -- DEBUG
+			--ZGV:Print("|cd3d3d3- desc: %s|r", desc)                                                                            -- DEBUG
+			if (isCompleted) then
+				ZGV:Print("achieve %d", id)
+				ZGV:Print("|cd3d3d3(Name: %s)|r", name)
+			else
+				local numCriteria = _G.GetAchievementNumCriteria(id)
+				--ZGV:Print("|cd3d3d3- numCriteria: %d|r", numCriteria)                                                          -- DEBUG
+				local progress = _G.GetAchievementProgress(id)
+				if (isSkyshardAchievement) then
+					ZGV:Print("click Skyshard ||achieve %d/#",id)
+					ZGV:Print("|cffff99- Chose a number below for # above:|r")
+					for i = 1, numCriteria do
+						local criterionDesc,numCompleted,numRequired = _G.GetAchievementCriterion(id,i)
+						ZGV:Print("|cffff99- # = %d :: %s (Completed: %d/%d)|r", i, criterionDesc, numCompleted, numRequired)
+					end
+					ZGV:Print("|cffff99---|r")
+				else
+					for i = 1, numCriteria do
+						local criterionDesc,numCompleted,numRequired = _G.GetAchievementCriterion(id,i)
+						--ZGV:Print("|cd3d3d3- Criterion.%d: %s (%d/%d)|r", i, criterionDesc, numCompleted, numRequired)         -- DEBUG
+					end
+				end
+			end
+		end
+	end
+end
+
+-- EVENT_LORE_BOOK_LEARNED (*luaindex* _categoryIndex_, *luaindex* _collectionIndex_, *luaindex* _bookIndex_, *luaindex* _guildIndex_, *bool* _isMaxRank_)
+function ZGV.EVENT_LORE_BOOK_LEARNED(_,_,cat,col,book,guild,isMaxRank)
+	if (ZGV.Creator) then
+		local title,_,_,_ = _G.GetLoreBookInfo(cat,col,book)
+		ZGV:Print("click %s", title)
+		ZGV:Print("lorebook %s/%d/%d/%d",title,cat,col,book)
+	end
+end
+
 -----------------------------------------
 -- STARTUP
 -----------------------------------------
@@ -106,6 +191,18 @@ tinsert(ZGV.startups,function(self)
 		local EVENT_PLAYER_COMBAT_STATE = _G.EVENT_PLAYER_COMBAT_STATE
 		Events:AddEvent(EVENT_PLAYER_COMBAT_STATE)
 	end)
+tinsert(ZGV.startups,function(self)
+	local EVENT_ACHIEVEMENT_AWARDED = _G.EVENT_ACHIEVEMENT_AWARDED
+	Events:AddEvent(EVENT_ACHIEVEMENT_AWARDED)
+end)
+tinsert(ZGV.startups,function(self)
+	local EVENT_ACHIEVEMENT_UPDATED = _G.EVENT_ACHIEVEMENT_UPDATED
+	Events:AddEvent(EVENT_ACHIEVEMENT_UPDATED)
+end)
+tinsert(ZGV.startups,function(self)
+	local EVENT_LORE_BOOK_LEARNED = _G.EVENT_LORE_BOOK_LEARNED
+	Events:AddEvent(EVENT_LORE_BOOK_LEARNED)
+end)
 
 -----------------------------------------
 -- EVENT LIST  - now dynamic.

--- a/Events.lua
+++ b/Events.lua
@@ -142,31 +142,42 @@ function ZGV.EVENT_ACHIEVEMENT_UPDATED(_,_,id)
 		[1149] = "Writ Upon the Sky",
 	}
 	if not IgnoreAchievements[id] then
-		if (ZGV.Creator) then
+		if (ZGV.Creator or ZGV.DEV) then
 			local name,desc,_,_,isCompleted,_,_ = _G.GetAchievementInfo(id)
 			local isSkyshardAchievement,_ = string.find(name,"Skyshard")
-			--ZGV:Print("|cd3d3d3Achievement Updated: %d:%s (isCompleted: %s)|r",id,name,tostring(isCompleted))                  -- DEBUG
-			--ZGV:Print("|cd3d3d3- isSkyshardAchievement: %s|r", tostring(isSkyshardAchievement))                                -- DEBUG
-			--ZGV:Print("|cd3d3d3- desc: %s|r", desc)                                                                            -- DEBUG
+			if (ZGV.DEV) then
+				ZGV:Debug("|cd3d3d3Achievement Updated: %d:%s (isCompleted: %s)|r",id,name,tostring(isCompleted))
+				ZGV:Debug("|cd3d3d3- isSkyshardAchievement: %s|r", tostring(isSkyshardAchievement))
+				ZGV:Debug("|cd3d3d3- desc: %s|r", desc)
+			end
 			if (isCompleted) then
 				ZGV:Print("achieve %d", id)
 				ZGV:Print("|cd3d3d3(Name: %s)|r", name)
 			else
 				local numCriteria = _G.GetAchievementNumCriteria(id)
-				--ZGV:Print("|cd3d3d3- numCriteria: %d|r", numCriteria)                                                          -- DEBUG
-				local progress = _G.GetAchievementProgress(id)
+				if (ZGV.DEV) then
+					ZGV:Debug("|cd3d3d3- numCriteria: %d|r", numCriteria)
+				end
+					local progress = _G.GetAchievementProgress(id)
 				if (isSkyshardAchievement) then
 					ZGV:Print("click Skyshard ||achieve %d/#",id)
 					ZGV:Print("|cffff99- Chose a number below for # above:|r")
 					for i = 1, numCriteria do
 						local criterionDesc,numCompleted,numRequired = _G.GetAchievementCriterion(id,i)
-						ZGV:Print("|cffff99- # = %d :: %s (Completed: %d/%d)|r", i, criterionDesc, numCompleted, numRequired)
+						if (ZGV.DEV) then
+							ZGV:Debug("|cffff99- # = %d :: %s (Completed: %d/%d)|r", i, criterionDesc, numCompleted, numRequired)
+						else
+							if (numCompleted == numRequired) then
+								ZGV:Print("|cffff99- # = %d :: %s|r", i, criterionDesc)		
+							end
+						end
 					end
-					ZGV:Print("|cffff99---|r")
 				else
 					for i = 1, numCriteria do
 						local criterionDesc,numCompleted,numRequired = _G.GetAchievementCriterion(id,i)
-						--ZGV:Print("|cd3d3d3- Criterion.%d: %s (%d/%d)|r", i, criterionDesc, numCompleted, numRequired)         -- DEBUG
+						if (ZGV.DEV) then
+							ZGV:Debug("|cd3d3d3- Criterion.%d: %s (%d/%d)|r", i, criterionDesc, numCompleted, numRequired)
+						end
 					end
 				end
 			end

--- a/Options.lua
+++ b/Options.lua
@@ -82,6 +82,7 @@ local defaultChar = {
   stephistory = {},
   goodbadguides = {},
   ignoredguides = {},
+  creator = false,
 }
 
 -- These are the account settings like options that will likely be the same for all characters.

--- a/SlashCommands.lua
+++ b/SlashCommands.lua
@@ -47,6 +47,10 @@ function ZGV.SlashCommandHandler(text)		--TODO
 		ZGV.Viewer:Hide_GuideViewer()
 	elseif text == "config" then
 		ZGV.Settings:OpenSettings()
+	elseif text == "creator" then
+		ZGV.Creator = not ZGV.Creator
+		self.sv.char.creator = not self.sv.char.creator
+		ZGV:Print(("Creator Mode is now %s"):format(self.sv.char.creator and "on" or "off"))
 	else
 		ZGV:Print(help_string)
 	end

--- a/ZGESO.lua
+++ b/ZGESO.lua
@@ -196,6 +196,10 @@ local function ZGV_Initialized(eventCode, addOnName)
 
   self:RegisterKeyBindings() -- What appears in the ESO > CONTROLS > Keybindings window
 
+  if (self.sv.char.creator) then
+    ZGV.Creator = true
+  end
+
   -- pre-startup 'modules', if anyone wants to run stuff at addon init, before the troo startups.
   for i, init in ipairs(self.inits) do
     init(self)


### PR DESCRIPTION
First, please note that this code only adds new features, it does not remove or change any existing features.

Basically, this pull request will add a new feature to the addon called "Creator Mode".   The idea for this mode is simply that, with it enabled, those who are creating and/or editing guides will receive additional information in the chat window which would not normally be of interest to regular players.   As of this pull request, the only thing it does is add the features mentioned below.

To TOGGLE "Creator Mode" simply type `/zgv creator` in the chat window.   You will see where it tells you whether you've toggled it on or off.   This setting is saved and will persist until it's changed again via the chat window command.   Please note that it is OFF by default.

"Creator Mode" is intended to provide useful information to those who are creating or editing guides.  It will not serve as a substitute for being familiar with the format of the guides.   Truly, it's just to minimize the need to be looking at other online sources of information by providing that data directly to the player as they play through the game.   For now, there are three things included with "Creator Mode" (with plans for more to be added later on):

### Lorebook Information
When you click on any lorebook in the game (that you have not read previously) you will receive a chat message in bright yellow that looks like how you would use it in the guide:
![Lorebook](https://i.imgur.com/75jnqjs.jpg)
Please note that you will get this message for all lorebooks the **first** time they're read, including "bookshelves".

### Achievement Completion
When you complete an achievement, you'll receive the following notification.   This is useful for things like exploring delves, amongst other things.
![Achievements](https://i.imgur.com/TPZRXxn.jpg)

### Skyshards
Guides which involve the clicking of skyshards utilize checking achievements with multiple criteria.   So, what you have to use is the achievement number plus the exact criterion number for the skyshard in question.   This new feature will provide you with the syntax that is most often used in the guides (in bright yellow), and then give you a list of the skyshards which you have completed thus far in the zone (which will include the one you just clicked.)   If you're progressing through a zone and keep track of all skyshards you click, the new line that appears in this list each time will always be the one you want.
![Achievements](https://i.imgur.com/MQ0AZek.jpeg)
