### PR TITLE
Fix extraneous/unrelated bug reporting caused by in-game event

### DIFF
--- a/Quest.lua
+++ b/Quest.lua
@@ -180,7 +180,7 @@ function Quests:SetConditionCoords(journalIndex,stepnum,condnum, typ,m,x,y,r,b1,
 		error("Quests:SetConditionCoords without journalIndex, stepnum or condnum")
 	end
 	local quest = Quests:GetQuest(journalIndex)
-	if not quest then return end  -- shouldn't happen!
+	if not quest or not quest.steps then return end  -- shouldn't happen!
 	if quest.steps[stepnum] ~= nil then
 		local step = quest.steps[stepnum]
 		if not step then return end


### PR DESCRIPTION
This is a fix for code that is causing the following bug report to randomly occur in game:
```
user:/AddOns/ZGESO/Quest.lua:184: attempt to index a nil value
stack traceback:
user:/AddOns/ZGESO/Quest.lua:184: in function 'Quests:SetConditionCoords'
|caaaaaa<Locals> self = [table:1]{class = "Quests"}, journalIndex = 12, stepnum = 3, condnum = 1, typ = 14, m = "orsinium_base", x = 0.32251861691475, y = 0.26622951030731, r = 0, b1 = T, b2 = T, GetByPrefix = user:/AddOns/ZGESO/Functions.lua:449, quest = [table:2]{name = "", id = 3360001} </Locals>|r
user:/AddOns/ZGESO/QuestTracker.lua:138: in function 'QuestTracker:EVENT_QUEST_POSITION_REQUEST_COMPLETE'
|caaaaaa<Locals> self = [table:3]{}, event = 131103, requestid = 594, typ = 14, x = 0.32251861691475, y = 0.26622951030731, r = 0, wtf1 = T, wtf2 = T, request = [table:4]{journalIndex = 12, stepnum = 3, condnum = 1} </Locals>|r
user:/AddOns/ZGESO/Events.lua:52: in function 'EventHandler'
|caaaaaa<Locals> event = 131103, self = [table:5]{}, eventString = "EVENT_QUEST_POSITION_REQUEST_C...", _ = 1, hand = [table:3], func = user:/AddOns/ZGESO/QuestTracker.lua:135, funcSelf = [table:3] </Locals>|r
```

Basically, this is being caused because the event EVENT_QUEST_POSITION_REQUEST_COMPLETE is returning something, on occasion, that the addon is not designed to handle.  I'm not sure if this is because it's a bug in the game, or just something quirky with the API.   But, the reality is that the bug is not really causing any issues with the guide at all -- it's just causing a bug report.

Anyway, this fix is really just an additional "sanity check" within the code.   It's basically saying that if the EVENT doesn't return what we're expecting, then just ignore it.

I had this bug happen to me as well, and it was utterly random and I didn't even notice that it happened until much later when I saw it was in my bug reports.   It didn't affect the addon in any way as far as I could tell.   Personally, I think it's safe to add this sanity check - even if it did cause an unforeseen issue in the future, it'd be a lot easier to trackdown/fix knowing when something isn't working than just some ultra random bug report that means/does nothing.