### PR TITLE
Craglorn guide bug fix

### DIFF
--- a/Guides/Expansions.lua
+++ b/Guides/Expansions.lua
@@ -665,6 +665,7 @@ step
 goto 55.39,41.69
 talk Little Leaf
 turnin A Leaf in the Wind
+accept The Serpent's Fang
 step
 goto 58.27,42.70
 click Ilthag's Undertower |achieve 887
@@ -686,7 +687,7 @@ step
 goto 18.26,47.56
 kill Rahk and Vosh
 kill Ilthag Ironblood
-'Explore Ilthag's Undertower |achieve 887
+'Explore Ilthag's Undertower |q The Serpent's Fang/Kill Ilthag Ironblood
 step
 goto 38.21,61.98
 talk Little Leaf |q The Serpent's Fang/Talk to Little Leaf


### PR DESCRIPTION
I'm surprised this bug was still in the guide, but basically it just never accepted the quest "The Serpent's Fang".  The guide did all of the steps for the quest, but never actually had a line to accept it.   I also adjusted the delve after you accept it to require that the player kill the boss for the quest, not just for the achievement (otherwise, if you had done the achievement but not finished the quest, the quest objective would never show for you.)

Anyway, it was a serious bug, but a very simple fix.